### PR TITLE
Command level help overwrite

### DIFF
--- a/src/commands/help.cmd.ts
+++ b/src/commands/help.cmd.ts
@@ -25,6 +25,7 @@ cmd.executor = async ({ }, { }, { rest, options, commandSet, message }) => {
         if (!command || args.length != 0)
             await reply(message, template(options.localization.help.commandNotFound, { command: cmdPath.join(" ") }));
         else {
+            if (await command.help(message, options)) return;
             const embed = HelpUtils.Command.embedHelp(command, options.prefix, options.localization);
             await reply(message, { embed });
         }

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -14,6 +14,7 @@ import { CommandResultUtils } from './CommandResult';
 import { CommandResultError } from './CommandResultError';
 import { ReadonlyCommandCollection, CommandCollection } from './CommandCollection';
 import { CanUseCommandCb } from './callbacks/CanUseCommandCb';
+import { HelpCb } from './callbacks/HelpCb';
 
 
 export class Command {
@@ -32,6 +33,7 @@ export class Command {
         private readonly _flagsShortcuts: ReadonlyMap<Char, string>,
         private readonly _executor: CommandExecutor<any> | undefined,
         private readonly _canUse: CanUseCommandCb | undefined,
+        private readonly _help: HelpCb | undefined,
         public readonly ignored: boolean,
         public readonly devOnly: boolean,
         public readonly guildOnly: boolean
@@ -64,6 +66,7 @@ export class Command {
             ),
             data.executor,
             data.def.canUse,
+            data.def.help,
             data.def.ignore ?? resolveInheritance("ignored", false),
             data.def.devOnly ?? resolveInheritance("devOnly", false),
             data.def.guildOnly ?? resolveInheritance("guildOnly", false),

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -102,6 +102,18 @@ export class Command {
         return true;
     }
 
+    /**
+     * Call the help handler of this command and return true.
+     * Return false if handler is undefined.
+     * @param message 
+     * @param options 
+     */
+    async help(message: Message, options: ParseOptions): Promise<boolean> {
+        if (!this._help) return false;
+        await this._help(this, { message, options, commandSet: this.commandSet });
+        return true;
+    }
+
     /** @internal */
     async execute(message: Message, inputArguments: string[], options: ParseOptions, commandSet: CommandSet) {
 

--- a/src/models/callbacks/HelpCb.ts
+++ b/src/models/callbacks/HelpCb.ts
@@ -7,4 +7,4 @@ export type HelpCb = (command: Command, context: {
     message: Message;
     options: ParseOptions;
     commandSet: CommandSet;
-}) => void;
+}) => void | Promise<void>;

--- a/src/models/callbacks/HelpCb.ts
+++ b/src/models/callbacks/HelpCb.ts
@@ -1,0 +1,10 @@
+import { Message } from "discord.js";
+import { Command } from "../Command";
+import { ParseOptions } from "../ParseOptions";
+import { CommandSet } from "../CommandSet";
+
+export type HelpCb = (command: Command, context: {
+    message: Message;
+    options: ParseOptions;
+    commandSet: CommandSet;
+}) => void;

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -28,6 +28,11 @@ export type CommandDefinition = {
      * If defined, this callback is called when help is needed for this command instead of default help.
      */
     readonly help?: HelpCb;
+    /**
+     * If set to true and `help` is defined, this command's `help` handler is used for sub command that not defined a `help` handler.
+     * (default is false)
+     */
+    readonly useHelpOnSubs?: boolean;
 
     /** Sub-commands of this command. */
     readonly subs?: { readonly [name: string]: CommandDefinition };
@@ -41,3 +46,4 @@ export type CommandDefinition = {
     /** If set to true, this command can only be executed from a server. (default is false). [inheritable] */
     readonly guildOnly?: boolean;
 }
+

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -2,6 +2,7 @@ import { ArgDefinition } from "./ArgDefinition";
 import { FlagDefinition } from "./FlagDefinition";
 import { RestDefinition } from "./RestDefinition";
 import { CanUseCommandCb } from "../callbacks/CanUseCommandCb";
+import { HelpCb } from "../callbacks/HelpCb";
 
 export type CommandDefinition = {
     /** alias names for this command. */
@@ -22,6 +23,11 @@ export type CommandDefinition = {
      * If the result is a string, the command is not executed and a reply message with the string is returned.
      */
     readonly canUse?: CanUseCommandCb;
+
+    /**
+     * If defined, this callback is called when help is needed for this command instead of default help.
+     */
+    readonly help?: HelpCb;
 
     /** Sub-commands of this command. */
     readonly subs?: { readonly [name: string]: CommandDefinition };


### PR DESCRIPTION
resolve #39 

Add properties to `CommandDefinition`:
- `help`: a handler that is called when the build-in help command is used on this command.
- `useHelpOnSubs`: If set to true, the `help` handler is passed on sub commands if those sub commands's `help` handler is undefined.