### PR TITLE
Option delete message

### DIFF
--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -35,7 +35,8 @@ export class Command {
         private readonly _help: HelpCb | undefined,
         public readonly ignored: boolean,
         public readonly devOnly: boolean,
-        public readonly guildOnly: boolean
+        public readonly guildOnly: boolean,
+        public readonly deleteMessage: boolean,
     ) { }
 
     static build<T extends CommandDefinition>(commandSet: CommandSet, data: CommandData<T>): Command {
@@ -76,6 +77,7 @@ export class Command {
             data.def.ignore ?? resolveInheritance("ignored", false),
             data.def.devOnly ?? resolveInheritance("devOnly", false),
             data.def.guildOnly ?? resolveInheritance("guildOnly", false),
+            data.def.deleteMessage ?? resolveInheritance("deleteMessage", false),
         );
 
         for (const subName in data.subs)

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -136,7 +136,9 @@ export class CommandSet {
         if (result !== true) return CommandResultUtils.unauthorizedUser(command);
 
         try {
-            return CommandResultUtils.ok(command, await command.execute(message, args, opts, this));
+            const result = await command.execute(message, args, opts, this);
+            if (command.deleteMessage && message.channel.type === "text") await message.delete().catch(() => { });
+            return CommandResultUtils.ok(command, result);
         } catch (e) {
             if (e instanceof CommandResultError) {
                 if (e.replyMessage && e.replyMessage !== "") await Reply(e.replyMessage);

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -45,5 +45,7 @@ export type CommandDefinition = {
     readonly devOnly?: boolean;
     /** If set to true, this command can only be executed from a server. (default is false). [inheritable] */
     readonly guildOnly?: boolean;
+    /** If set to true, the command message will be deleted after command execution. */
+    readonly deleteMessage?: boolean;
 }
 


### PR DESCRIPTION
resolve #42 

Add inheritable option `deleteMessage` to `CommandDefinition`.  
If set to true, the message that execute this command is deleted after the execution. Default is false.