### PR TITLE
Mention as prefix

### DIFF
--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -155,4 +155,5 @@ const defaultOptions: ParseOptions = {
     prefix: "",
     devIDs: [],
     localization: defaultLocalization,
+    allowMentionAsPrefix: false,
 };

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -113,11 +113,17 @@ export class CommandSet {
 
         const opts = deepMerge({}, defaultOptions, this._defaultOptions, options);
 
-        // Extract command & arguments from message
-        if (!message.content.startsWith(opts.prefix)) return CommandResultUtils.notPrefixed();
+        let content: string;
+        const botMentionStr = `<@!${message.client.user?.id}>`
+        if (opts.allowMentionAsPrefix && message.content.startsWith(botMentionStr))
+            content = message.content.substring(botMentionStr.length);
+        else if (message.content.startsWith(opts.prefix))
+            content = message.content.substring(opts.prefix.length);
+        else
+            return CommandResultUtils.notPrefixed();
 
         // extract the command & arguments from message
-        const rawArgs = (message.content.substring(opts.prefix.length).match(/[^\s"']+|"([^"]*)"|'([^']*)'/g) || [])
+        const rawArgs = (content.match(/[^\s"']+|"([^"]*)"|'([^']*)'/g) || [])
             .map(a => /^(".*"|'.*')$/.test(a) ? a.substring(1, a.length - 1) : a);
 
         const { command, args } = this.resolve(rawArgs);

--- a/src/models/ParseOptions.ts
+++ b/src/models/ParseOptions.ts
@@ -7,4 +7,6 @@ export interface ParseOptions {
     devIDs: readonly string[];
     /** A localization object */
     localization: Localization;
+    /** If set to true, a mention to the bot can be used instead of a prefix (default is false). */
+    allowMentionAsPrefix: boolean;
 }


### PR DESCRIPTION
resolve #41 

`ParseOptions.allowMentionAsPrefix` : if set to true, message that start with a mention to bot user is treated as command message. (default is false).