### PR TITLE
Command throttling

### DIFF
--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -22,7 +22,7 @@ import { Throttler } from './Throttler';
 
 export class Command {
 
-    private _throttler?: Throttler;
+    private readonly _throttler: Throttler | null | undefined;
 
     private constructor(
         public readonly filepath: string | null,
@@ -40,14 +40,14 @@ export class Command {
         private readonly _executor: CommandExecutor<any> | undefined,
         private readonly _canUse: CanUseCommandCb | undefined,
         private readonly _help: HelpCb | undefined,
-        private readonly _throttling: ThrottlingDefinition | undefined,
+        throttling: ThrottlingDefinition | null | undefined,
         private readonly _useThrottlerOnSubs: boolean,
         public readonly ignored: boolean,
         public readonly devOnly: boolean,
         public readonly guildOnly: boolean,
         public readonly deleteMessage: boolean,
     ) {
-        if (_throttling) this._throttler = new Throttler(_throttling.count, _throttling.duration);
+        this._throttler = throttling ? new Throttler(throttling.count, throttling.duration) : throttling;
     }
 
     /** @internal */
@@ -112,6 +112,7 @@ export class Command {
     // === Getter =====================================================
 
     get throttler(): Throttler | undefined {
+        if (this._throttler === null) return undefined;
         if (this._throttler) return this._throttler;
         if (this.parent && this.parent._useThrottlerOnSubs) return this.parent.throttler;
         return undefined;

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -17,6 +17,7 @@ import { CanUseCommandCb } from './callbacks/CanUseCommandCb';
 import { HelpCb } from './callbacks/HelpCb';
 import { parseValue } from '../other/parsing/parseValue';
 import { ParsableType } from './ParsableType';
+import { ThrottlingDefinition } from './definition/ThrottlingDefinition';
 
 export class Command {
 
@@ -36,6 +37,7 @@ export class Command {
         private readonly _executor: CommandExecutor<any> | undefined,
         private readonly _canUse: CanUseCommandCb | undefined,
         private readonly _help: HelpCb | undefined,
+        public readonly throttling: ThrottlingDefinition | undefined,
         public readonly ignored: boolean,
         public readonly devOnly: boolean,
         public readonly guildOnly: boolean,
@@ -82,6 +84,7 @@ export class Command {
             data.executor,
             data.def.canUse,
             data.def.help ?? parentHelp,
+            data.def.throttling,
             data.def.ignore ?? resolveInheritance("ignored", false),
             data.def.devOnly ?? resolveInheritance("devOnly", false),
             data.def.guildOnly ?? resolveInheritance("guildOnly", false),

--- a/src/models/CommandResult.ts
+++ b/src/models/CommandResult.ts
@@ -13,7 +13,7 @@ export type CommandResult =
         readonly error: any;
     } |
     {
-        readonly status: "no executor" | "guild only" | "dev only" | "unauthorized user";
+        readonly status: "no executor" | "guild only" | "dev only" | "unauthorized user" | "throttling";
         readonly command: Command;
     } |
     {
@@ -78,6 +78,9 @@ export namespace CommandResultUtils {
 
     /** @internal */
     export function unauthorizedUser(command: Command): CommandResult { return { status: "unauthorized user", command }; }
+
+    /** @internal */
+    export function throttling(command: Command): CommandResult { return { status: "throttling", command }; }
 
     /** @internal */
     export function notPrefixed(): CommandResult { return { status: "not prefixed" }; }

--- a/src/models/Throttler.ts
+++ b/src/models/Throttler.ts
@@ -1,0 +1,42 @@
+export class Throttler {
+
+    private _current = 0;
+    private _timeout: NodeJS.Timeout | undefined = undefined;
+
+    constructor(
+        /** How many time the throttler can be triggered. */
+        public readonly count: number,
+        /** Time in seconds since the first trigger before the throttler is reset. */
+        public readonly duration: number,
+    ) { }
+
+    /** The number of time this throttler has been triggered. */
+    get current() { return this._current; }
+
+    /** Return true if this throttler has reached the limit, false otherwise. */
+    get throttled() { return this._current >= this.count; }
+
+    /** Return the time in seconds until the throttler is reset. */
+    get cooldown() {
+        return this._timeout ?
+            Math.ceil(((this._timeout as any)._idleStart + (this._timeout as any)._idleTimeout) / 1000 - process.uptime()) :
+            0;
+    }
+
+    /** Reset this throttler. */
+    reset(): void {
+        if (this._timeout) clearTimeout(this._timeout);
+        this._timeout = undefined;
+        this._current = 0;
+    }
+
+    /** Increment this throttler. 
+     * Return true if the limit has not been reached, false otherwise.
+    */
+    add(): boolean {
+        const reachedLimit = this.throttled;
+        this._current++;
+        if (!this._timeout) this._timeout = setTimeout(() => this.reset(), this.duration);
+        return reachedLimit;
+    }
+}

--- a/src/models/Throttler.ts
+++ b/src/models/Throttler.ts
@@ -36,7 +36,7 @@ export class Throttler {
     add(): boolean {
         const reachedLimit = this.throttled;
         this._current++;
-        if (!this._timeout) this._timeout = setTimeout(() => this.reset(), this.duration);
+        if (!this._timeout) this._timeout = setTimeout(() => this.reset(), this.duration * 1000);
         return reachedLimit;
     }
 }

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -3,6 +3,7 @@ import { FlagDefinition } from "./FlagDefinition";
 import { RestDefinition } from "./RestDefinition";
 import { CanUseCommandCb } from "../callbacks/CanUseCommandCb";
 import { HelpCb } from "../callbacks/HelpCb";
+import { ThrottlingDefinition } from "./ThrottlingDefinition";
 
 export type CommandDefinition = {
     /** alias names for this command. */
@@ -17,6 +18,8 @@ export type CommandDefinition = {
     readonly flags?: { readonly [name: string]: FlagDefinition };
     /** Define a name and a description for a rest argument. Used for help purpose. */
     readonly rest?: RestDefinition;
+
+    readonly throttling?: ThrottlingDefinition;
 
     /** Determine if a user can use this commands.
      * If the result is true, the command is executed.

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -19,7 +19,7 @@ export type CommandDefinition = {
     /** Define a name and a description for a rest argument. Used for help purpose. */
     readonly rest?: RestDefinition;
 
-    readonly throttling?: ThrottlingDefinition;
+    readonly throttling?: ThrottlingDefinition | null;
     /** If set to true, sub-commands while use this command's throttler. (default is true) */
     readonly useThrottlerForSubs?: boolean;
 

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -20,6 +20,8 @@ export type CommandDefinition = {
     readonly rest?: RestDefinition;
 
     readonly throttling?: ThrottlingDefinition;
+    /** If set to true, sub-commands while use this command's throttler. (default is true) */
+    readonly useThrottlerForSubs?: boolean;
 
     /** Determine if a user can use this commands.
      * If the result is true, the command is executed.

--- a/src/models/definition/ThrottlingDefinition.ts
+++ b/src/models/definition/ThrottlingDefinition.ts
@@ -1,6 +1,6 @@
 export interface ThrottlingDefinition {
     /** Number of times the command can be used. */
-    count: number;
+    readonly count: number;
     /** Duration after which the usage count is reset. */
-    duration: number;
+    readonly duration: number;
 }

--- a/src/models/definition/ThrottlingDefinition.ts
+++ b/src/models/definition/ThrottlingDefinition.ts
@@ -1,0 +1,6 @@
+export interface ThrottlingDefinition {
+    /** Number of times the command can be used. */
+    count: number;
+    /** Duration after which the usage count is reset. */
+    duration: number;
+}


### PR DESCRIPTION
resolve #36 

# Features
Add new parameters to `CommandDefinition`:
- `throttling`: Define a throttler for the command with the following properties:
  - `count`: how many time the command can be executed.
  - `duration`: time in second after which the throttler is reset.
- `useThrottlerForSubs`: If set to true, sub-commands will used same `Throttler` object as the current command. default value is `true`.
- `throttling` can be set to `null`, in this case the command/sub-command while not have throttling. (used to not use the parent throttling).

# Example

```ts

const cmd = makeCommand("ping", {
    description: "Pong !",
    throttling: { count: 3, duration: 25 },
    subs: {
        aa: {},
        bb: { throttling: null },
        cc: {
            useThrottlerForSubs: false,
            subs: {
                dd: { }
            },
        ee: {
            throttling: { count: 5, duration: 100 }
        }
    }
});
```
| Command    | Throttling                 |
|------------|----------------------------|
| ping       | Use his own throttler      |
| ping aa    | Use same throttler as ping |
| ping bb    | Have no throttler          |
| ping cc    | Use same throttler as ping |
| ping cc dd | Have no throttler          |
| ping ee    | Use his own throttler      |