### PR TITLE
Throttling enhance

### DIFF
--- a/src/commands/cmd.cmd.ts
+++ b/src/commands/cmd.cmd.ts
@@ -1,4 +1,5 @@
 import { makeCommand } from "../other/makeCommand";
+import { Command } from "..";
 
 const cmd = makeCommand("cmd", {
     devOnly: true,
@@ -8,6 +9,16 @@ const cmd = makeCommand("cmd", {
             aliases: ["r"],
             description: "Reload a command",
             args: { command: { type: "string", description: "Name of the command to reload." } }
+        },
+        throttling: {
+            aliases: ["t"],
+            description: "Get data about command throttler",
+            rest: { type: "string", name: "command" },
+            flags: {
+                reset: { type: "boolean", defaultValue: false, shortcut: "r", description: "Reset the trottler" },
+                "reset-all": { type: "boolean", defaultValue: false, shortcut: "R", description: "Reset all throttlers" }
+            },
+            examples: ["cmd t foo", "cmd t foo -r", "cmd t foo -R", "cmd t -R"]
         }
     }
 });
@@ -24,6 +35,51 @@ cmd.subs.reload.executor = async ({ command }, { }, { commandSet, message }) => 
         await message.channel.send(":white_check_mark: Command reloaded").catch(() => { });
     } catch (e) {
         await message.channel.send(`:x: Fail to reload command \`\`\`\n${e}\n\`\`\``).catch(() => { });
+    }
+}
+
+cmd.subs.throttling.executor = async (_, { reset, "reset-all": resetAll }, { commandSet, message, rest }) => {
+    function resetAllThrottling(cmd: Command) {
+        for (const sub of cmd.subs)
+            resetAllThrottling(sub);
+        cmd.throttler?.reset();
+    }
+
+    if (resetAll && rest.length === 0) {
+        for (const c of commandSet.commands)
+            resetAllThrottling(c);
+        await message.channel.send(":white_check_mark: All throttlers has been reset.");
+        return;
+    }
+
+    const commandName = `\`${rest.join(" ")}\``;
+    const { command } = commandSet.resolve(rest);
+    if (!command) {
+        await message.channel.send(`:x: Command ${commandName} not found.`);
+        return;
+    }
+
+    if (resetAll) {
+        resetAllThrottling(command);
+        await message.channel.send(`:white_check_mark: All throttlers of ${commandName} has been reset.`);
+        return;
+    }
+
+    const throttler = command.throttler;
+    if (!throttler) {
+        await message.channel.send(`:x: Throttling is not enabled on ${commandName}.`);
+        return;
+    }
+
+    if (reset) {
+        throttler.reset();
+        await message.channel.send(`:white_check_mark: Throttling has been reset for ${commandName}.`);
+    } else {
+        await message.channel.send(`
+**Command**: ${commandName}
+**Usage**: ${throttler.current} / ${throttler.count}
+**Cooldown**: ${throttler.cooldown} / ${throttler.duration} seconds
+        `);
     }
 }
 

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -23,7 +23,7 @@ import { Throttler } from './Throttler';
 export class Command {
 
     private readonly _throttler: Throttler | null | undefined;
-    public readonly _throttlingIncludeAdmin: boolean;
+    public readonly _throttlingIncludeAdmins: boolean;
 
     private constructor(
         public readonly filepath: string | null,
@@ -49,7 +49,7 @@ export class Command {
         public readonly deleteMessage: boolean,
     ) {
         this._throttler = throttling ? new Throttler(throttling.count, throttling.duration) : throttling;
-        this._throttlingIncludeAdmin = throttling?.includeAdmin ?? false;
+        this._throttlingIncludeAdmins = throttling?.includeAdmins ?? false;
     }
 
     /** @internal */
@@ -176,7 +176,7 @@ export class Command {
         if (
             this.throttler &&
             !options.devIDs.includes(message.author.id) &&
-            !(!this._throttlingIncludeAdmin && message.member && message.member.permissions.has("ADMINISTRATOR"))
+            !(!this._throttlingIncludeAdmins && message.member && message.member.permissions.has("ADMINISTRATOR"))
         )
             this.throttler.add();
 

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -23,7 +23,7 @@ import { Throttler } from './Throttler';
 export class Command {
 
     private readonly _throttler: Throttler | null | undefined;
-    public readonly _throttlingAffectAdmin: boolean;
+    public readonly _throttlingIncludeAdmin: boolean;
 
     private constructor(
         public readonly filepath: string | null,
@@ -49,7 +49,7 @@ export class Command {
         public readonly deleteMessage: boolean,
     ) {
         this._throttler = throttling ? new Throttler(throttling.count, throttling.duration) : throttling;
-        this._throttlingAffectAdmin = throttling?.includeAdmin ?? false;
+        this._throttlingIncludeAdmin = throttling?.includeAdmin ?? false;
     }
 
     /** @internal */
@@ -176,7 +176,7 @@ export class Command {
         if (
             this.throttler &&
             !options.devIDs.includes(message.author.id) &&
-            !(!this._throttlingAffectAdmin && message.member && message.member.permissions.has("ADMINISTRATOR"))
+            !(!this._throttlingIncludeAdmin && message.member && message.member.permissions.has("ADMINISTRATOR"))
         )
             this.throttler.add();
 

--- a/src/models/definition/ThrottlingDefinition.ts
+++ b/src/models/definition/ThrottlingDefinition.ts
@@ -4,5 +4,5 @@ export interface ThrottlingDefinition {
     /** Duration after which the usage count is reset. */
     readonly duration: number;
     /** If set to true, user with administrator permission are also affected by this throttling. (default is false) */
-    readonly includeAdmin?: boolean;
+    readonly includeAdmins?: boolean;
 }

--- a/src/models/definition/ThrottlingDefinition.ts
+++ b/src/models/definition/ThrottlingDefinition.ts
@@ -3,4 +3,6 @@ export interface ThrottlingDefinition {
     readonly count: number;
     /** Duration after which the usage count is reset. */
     readonly duration: number;
+    /** If set to true, user with administrator permission are also affected by this throttling. (default is false) */
+    readonly includeAdmin?: boolean;
 }


### PR DESCRIPTION
# Feature
- Devs and admins are not affected by throttling.
- It's possible to affect admins with throttling with the `includeAdmins` flag in `ThrottlingDefinition`.
- Add a sub command to the build-in command `cmd` to check or reset throttlers.