### PR TITLE
Display command in help and list only if can be used

### DIFF
--- a/src/commands/help.cmd.ts
+++ b/src/commands/help.cmd.ts
@@ -23,6 +23,7 @@ cmd.executor = async ({ }, { }, { rest, options, commandSet, message }) => {
         if (!command || args.length != 0)
             await reply(message, template(options.localization.help.commandNotFound, { command: rest.join(" ") }));
         else {
+            if (command.canUse(message.author, message) !== true) return;
             if (await command.help(message, options)) return;
             const embed = HelpUtils.Command.embedHelp(command, options.prefix, options.localization);
             await reply(message, { embed });

--- a/src/commands/list.cmd.ts
+++ b/src/commands/list.cmd.ts
@@ -17,7 +17,13 @@ const cmd = makeCommand("list", {
 cmd.executor = async ({ }, { detail }, { commandSet, options, message }) => {
 
     const raw = ListUtils.getRawListData(commandSet, options.localization);
-    const commands = options.devIDs.includes(message.author.id) ? raw.commands : raw.commands.filter(c => !c.command.devOnly);
+    const commands =
+        (
+            options.devIDs.includes(message.author.id) ?
+                raw.commands :
+                raw.commands.filter(c => !c.command.devOnly)
+        )
+            .filter(c => c.command.canUse(message.author, message) === true);
 
     const embed = new MessageEmbed()
         .setColor("#0099ff")


### PR DESCRIPTION
resolve #65 

- build-in help will not display help if the command cannot be used by the user.
- build-in list will ignore command that cannot be used by the user.