### PR TITLE
Check client permissions

### DIFF
--- a/src/data/localization.json
+++ b/src/data/localization.json
@@ -22,6 +22,7 @@
         "subCommands": "Sub commands",
         "aliases": "Aliases",
         "examples": "Examples",
+        "bot_permissions": "Required Bot Permissions",
         "default": "Type `{{prefix}}list` to get a list of all commands or `{{prefix}}help <command name>` to get help on a command.",
         "commandNotFound": "The command/sub-command `{{command}}` cannot be found.",
         "restTypeName": "list of {{type}}",

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -19,6 +19,7 @@ import { parseValue } from '../other/parsing/parseValue';
 import { ParsableType } from './ParsableType';
 import { ThrottlingDefinition } from './definition/ThrottlingDefinition';
 import { Throttler } from './Throttler';
+import { threadId } from 'worker_threads';
 
 export class Command {
 
@@ -166,6 +167,8 @@ export class Command {
 
     /** @internal */
     async execute(message: Message, inputArguments: string[], options: ParseOptions, commandSet: CommandSet) {
+
+        if (message.guild && !this.hasClientPermissions(message.guild)) throw new CommandResultError(CommandResultUtils.clientPermissions(this));
 
         if (this.throttler?.throttled) throw new CommandResultError(CommandResultUtils.throttling(this));
 

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -1,4 +1,4 @@
-import { Message, User } from 'discord.js';
+import { Message, User, PermissionString, Guild } from 'discord.js';
 import { CommandSet } from "./CommandSet";
 import { ParseOptions } from './ParseOptions';
 import { CommandData } from './CommandData';
@@ -29,6 +29,7 @@ export class Command {
         public readonly filepath: string | null,
         public readonly name: string,
         public readonly aliases: readonly string[],
+        private readonly _clientPermissions: PermissionString[],
         public readonly examples: readonly string[],
         public readonly description: string,
         public readonly parent: Command | null,
@@ -75,6 +76,7 @@ export class Command {
             filepath,
             data.name,
             data.def.aliases ?? [],
+            data.def.clientPermissions ?? [],
             data.def.examples ?? [],
             data.def.description ?? "",
             parent,
@@ -113,6 +115,8 @@ export class Command {
 
     // === Getter =====================================================
 
+    get clientPermissions() { return this._clientPermissions as readonly PermissionString[]; }
+
     get throttler(): Throttler | undefined {
         if (this._throttler === null) return undefined;
         if (this._throttler) return this._throttler;
@@ -129,6 +133,11 @@ export class Command {
             parents.unshift(parent);
 
         return parents;
+    }
+
+    /** Return true if the client have required permission for this guild. */
+    hasClientPermissions(guild: Guild) {
+        return guild.me && guild.me.hasPermission(this._clientPermissions);
     }
 
     // =====================================================

--- a/src/models/CommandResult.ts
+++ b/src/models/CommandResult.ts
@@ -13,7 +13,7 @@ export type CommandResult =
         readonly error: any;
     } |
     {
-        readonly status: "no executor" | "guild only" | "dev only" | "unauthorized user" | "throttling";
+        readonly status: "no executor" | "guild only" | "dev only" | "unauthorized user" | "throttling" | "client permissions";
         readonly command: Command;
     } |
     {
@@ -81,6 +81,9 @@ export namespace CommandResultUtils {
 
     /** @internal */
     export function throttling(command: Command): CommandResult { return { status: "throttling", command }; }
+    
+    /** @internal */
+    export function clientPermissions(command: Command): CommandResult { return { status: "client permissions", command }; }
 
     /** @internal */
     export function notPrefixed(): CommandResult { return { status: "not prefixed" }; }

--- a/src/models/definition/CommandDefinition.ts
+++ b/src/models/definition/CommandDefinition.ts
@@ -1,3 +1,4 @@
+import { PermissionString } from "discord.js";
 import { ArgDefinition } from "./ArgDefinition";
 import { FlagDefinition } from "./FlagDefinition";
 import { RestDefinition } from "./RestDefinition";
@@ -8,6 +9,8 @@ import { ThrottlingDefinition } from "./ThrottlingDefinition";
 export type CommandDefinition = {
     /** alias names for this command. */
     readonly aliases?: string[];
+    /** Define which permissions the client need to perform the command. */
+    readonly clientPermissions?: PermissionString[];
     /** A list of example for this command. */
     readonly examples?: string[];
     /** The description of this command. Used by help command. */

--- a/src/models/localization/Localization.ts
+++ b/src/models/localization/Localization.ts
@@ -14,6 +14,7 @@ export interface Localization {
         subCommands: string;
         aliases: string;
         examples: string;
+        bot_permissions: string;
         default: string;
         commandNotFound: string;
         restTypeName: string;

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -90,6 +90,10 @@ export namespace HelpUtils {
                 .map(a => `\`${a}\``).join(" ");
             if (aliases !== "") embed.addField(localization.help.aliases, aliases, false);
 
+            const clientPermissions = rawHelp.command.clientPermissions
+                .map(p => `\`${p}\``).join(" ");
+            if (clientPermissions !== "") embed.addField("", clientPermissions, false);
+
             const exemples = rawHelp.command.examples.map(e => `\`${e}\``).join("\n");
             if (exemples !== "") embed.addField(localization.help.examples, exemples, false);
 

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -92,7 +92,7 @@ export namespace HelpUtils {
 
             const clientPermissions = rawHelp.command.clientPermissions
                 .map(p => `\`${p}\``).join(" ");
-            if (clientPermissions !== "") embed.addField("", clientPermissions, false);
+            if (clientPermissions !== "") embed.addField(localization.help.bot_permissions, clientPermissions, false);
 
             const exemples = rawHelp.command.examples.map(e => `\`${e}\``).join("\n");
             if (exemples !== "") embed.addField(localization.help.examples, exemples, false);

--- a/src/other/makeCommand.ts
+++ b/src/other/makeCommand.ts
@@ -1,6 +1,7 @@
 import { CommandDefinition } from "../models/definition/CommandDefinition";
 import { CommandData } from "../models/CommandData";
 import { ParsableTypeName } from "../models/ParsableType";
+import { ArrayUtils } from "../utils/array";
 
 export function makeCommand<T extends CommandDefinition>(name: string, definition: T): CommandData<T> {
     let subs = {} as any;
@@ -22,6 +23,9 @@ export function makeCommand<T extends CommandDefinition>(name: string, definitio
 
     if (definition.rest && Array.isArray(definition.rest.type))
         definition.rest.type.sort(sortParsableType);
+
+    if (definition.clientPermissions)
+        (definition.clientPermissions as any) = ArrayUtils.distinct(definition.clientPermissions);
 
     return {
         def: definition,

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -2,4 +2,8 @@ export namespace ArrayUtils {
     export function isArray(o: any): o is any[] | readonly any[] {
         return Array.isArray(o);
     }
+
+    export function distinct<T>(a: T[]): T[] {
+        return [...new Set(a)];
+    }
 }


### PR DESCRIPTION
resolve #66 

- A command can define a list of permissions that the bot need to execute the action.
- If the client have not required permissions, the `CommandSet#parse` return a `CommandResult` with the status `client permissions`.
- The build-in help command display the list of required permissions.