### PR TITLE
✨ load ts command

### DIFF
--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -47,9 +47,9 @@ export class CommandSet {
      * Load command from the given folder path.<br>
      * Command file must have the extension `.cmd.js`
      * @param commandDirPath - path to the folder where the commands are (relative to node entry point).
+     * @param includeTS - if set to true, file with `.cmd.ts` extension are also loaded. Usefull if you use `ts-node` (default is false)
      */
-    loadCommands(commandDirPath: string) {
-        console.log(commandDirPath);
+    loadCommands(commandDirPath: string, includeTS = false) {
         try {
             if (require.main)
                 commandDirPath = path.resolve(
@@ -58,7 +58,11 @@ export class CommandSet {
                 );
             const cmdFiles = fs
                 .readdirSync(commandDirPath)
-                .filter((file) => file.endsWith(".cmd.js"));
+                .filter(
+                    (file) =>
+                        file.endsWith(".cmd.js") ||
+                        (includeTS && file.endsWith(".cmd.ts"))
+                );
             for (const file of cmdFiles) {
                 const filePath = path.resolve(
                     path.format({ dir: commandDirPath, base: file })

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,7 +4,11 @@ import env from "./env.json";
 
 const commands = new CommandSet({ prefix: env.prefix, devIDs: env.devIDs });
 commands.loadCommands("commands");
-commands.buildin("all");
+
+// manually load build-in commands
+// because there are supposed to be JS in production
+// CommandSet#buildin not load TS files.
+commands.loadCommands("../src/commands", true);
 
 const client = new Client();
 


### PR DESCRIPTION
- resolve #74 

### Features
`CommandSet#loadCommands(commandDirPath: string, includeTS = false)`, if `includeTS` is set to true, file with `.cmd.ts` extension are also loaded. (default is false)  
Useful when used with [`ts-node`](https://www.npmjs.com/package/ts-node).