### PR TITLE
Feat dev permission options

### DIFF
--- a/src/commands/help.cmd.ts
+++ b/src/commands/help.cmd.ts
@@ -37,7 +37,13 @@ cmd.executor = async (_a, _f, { rest, options, commandSet, message }) => {
                 })
             );
         else {
-            if (command.canUse(message.author, message) !== true) return;
+            if (
+                (!options.devIDs.includes(message.author.id) ||
+                    !options.skipDevsPermissionsChecking) &&
+                command.canUse(message.author, message) !== true
+            )
+                return;
+
             if (await command.help(message, options)) return;
             const embed = HelpUtils.Command.embedHelp(
                 command,

--- a/src/commands/list.cmd.ts
+++ b/src/commands/list.cmd.ts
@@ -17,10 +17,17 @@ const cmd = makeCommand("list", {
 
 cmd.executor = async (_a, { detail }, { commandSet, options, message }) => {
     const raw = ListUtils.getRawListData(commandSet, options.localization);
-    const commands = (options.devIDs.includes(message.author.id)
+    let commands = options.devIDs.includes(message.author.id)
         ? raw.commands
-        : raw.commands.filter((c) => !c.command.devOnly)
-    ).filter((c) => c.command.canUse(message.author, message) === true);
+        : raw.commands.filter((c) => !c.command.devOnly);
+
+    if (
+        !options.devIDs.includes(message.author.id) ||
+        !options.skipDevsPermissionsChecking
+    )
+        commands = commands.filter(
+            (c) => c.command.canUse(message.author, message) === true
+        );
 
     const embed = new MessageEmbed()
         .setColor("#0099ff")

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -213,4 +213,5 @@ const defaultOptions: ParseOptions = {
     devIDs: [],
     localization: defaultLocalization,
     allowMentionAsPrefix: false,
+    checkDevsPermissions: false,
 };

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -187,10 +187,15 @@ export class CommandSet {
         if (command.devOnly && !opts.devIDs.includes(message.author.id))
             return CommandResultUtils.devOnly(command);
 
-        const result = command.canUse(message.author, message);
-        if (typeof result === "string") await Reply(result);
-        if (result !== true)
-            return CommandResultUtils.unauthorizedUser(command);
+        if (
+            opts.devIDs.includes(message.author.id) &&
+            !opts.checkDevsPermissions
+        ) {
+            const result = command.canUse(message.author, message);
+            if (typeof result === "string") await Reply(result);
+            if (result !== true)
+                return CommandResultUtils.unauthorizedUser(command);
+        }
 
         try {
             const result = await command.execute(message, args, opts, this);

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -188,8 +188,8 @@ export class CommandSet {
             return CommandResultUtils.devOnly(command);
 
         if (
-            opts.devIDs.includes(message.author.id) &&
-            !opts.checkDevsPermissions
+            !opts.devIDs.includes(message.author.id) ||
+            !opts.skipDevsPermissionsChecking
         ) {
             const result = command.canUse(message.author, message);
             if (typeof result === "string") await Reply(result);
@@ -218,5 +218,5 @@ const defaultOptions: ParseOptions = {
     devIDs: [],
     localization: defaultLocalization,
     allowMentionAsPrefix: false,
-    checkDevsPermissions: false,
+    skipDevsPermissionsChecking: false,
 };

--- a/src/models/ParseOptions.ts
+++ b/src/models/ParseOptions.ts
@@ -9,4 +9,6 @@ export interface ParseOptions {
     localization: Localization;
     /** If set to true, a mention to the bot can be used instead of a prefix (default is false). */
     allowMentionAsPrefix: boolean;
+    /** If set to true, users with dev privileges are also subject to permission checking. (default is false) */
+    checkDevsPermissions: boolean;
 }

--- a/src/models/ParseOptions.ts
+++ b/src/models/ParseOptions.ts
@@ -9,6 +9,6 @@ export interface ParseOptions {
     localization: Localization;
     /** If set to true, a mention to the bot can be used instead of a prefix (default is false). */
     allowMentionAsPrefix: boolean;
-    /** If set to true, users with dev privileges are also subject to permission checking. (default is false) */
-    checkDevsPermissions: boolean;
+    /** If set to true, users with dev privileges are not subject to permissions checking. (default is false) */
+    skipDevsPermissionsChecking: boolean;
 }

--- a/test/commands/admin.cmd.ts
+++ b/test/commands/admin.cmd.ts
@@ -1,0 +1,11 @@
+import { makeCommand } from "../../src/index";
+
+const cmd = makeCommand("admin", {
+    canUse: () => false,
+});
+
+cmd.executor = async (_a, _f, { message }) => {
+    await message.reply(":rotating_light: **Nobody allowed**");
+};
+
+export default cmd;

--- a/test/index.ts
+++ b/test/index.ts
@@ -7,7 +7,7 @@ const commands = new CommandSet({
     devIDs: env.devIDs,
     skipDevsPermissionsChecking: env.skipDevsPermissionshecking,
 });
-commands.loadCommands("commands");
+commands.loadCommands("commands", true);
 
 // manually load build-in commands
 // because there are supposed to be JS in production

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,7 +2,11 @@ import { Client } from "discord.js";
 import { CommandSet } from "../src/index";
 import env from "./env.json";
 
-const commands = new CommandSet({ prefix: env.prefix, devIDs: env.devIDs });
+const commands = new CommandSet({
+    prefix: env.prefix,
+    devIDs: env.devIDs,
+    skipDevsPermissionsChecking: env.skipDevsPermissionshecking,
+});
 commands.loadCommands("commands");
 
 // manually load build-in commands

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "strict": true
+        "strict": true,
+        "resolveJsonModule": true
     }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "strict": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "esModuleInterop": true
     }
 }


### PR DESCRIPTION
- resolve #75 

### Feature
Add `skipDevsPermissionsChecking` to `ParseOptions`. If set to true, user with dev privileges are not subject to permissions checkings. Default is false.