### PR TITLE
Resolve Message channel type

### DIFF
--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -252,6 +252,7 @@ export class Command {
                 message,
                 guild: message.guild,
                 member: message.member,
+                channel: message.channel,
                 options,
                 commandSet,
                 command: this,

--- a/src/models/callbacks/CommandExecutor.ts
+++ b/src/models/callbacks/CommandExecutor.ts
@@ -1,4 +1,4 @@
-import { Message } from "discord.js";
+import { Message, DMChannel } from "discord.js";
 import { CommandSet } from "../CommandSet";
 
 import {
@@ -14,6 +14,24 @@ type IsGuildOnly<
     True,
     False
 > = S["guildOnly"] extends true ? True : False;
+
+type MessageExtension<S> = {
+    readonly guild: IsGuildOnly<
+        S,
+        NonNullable<Message["guild"]>,
+        Message["guild"]
+    >;
+    readonly member: IsGuildOnly<
+        S,
+        NonNullable<Message["member"]>,
+        Message["member"]
+    >;
+    readonly channel: IsGuildOnly<
+        S,
+        Exclude<Message["channel"], DMChannel>,
+        Message["channel"]
+    >;
+};
 
 export type CommandExecutor<
     T extends CommandDefinition = CommandDefinition,
@@ -41,30 +59,9 @@ export type CommandExecutor<
         readonly rest: undefined extends T["rest"]
             ? void
             : readonly ParsableTypeOf<NonNullable<T["rest"]>["type"]>[];
-        readonly message: Message & {
-            readonly guild: IsGuildOnly<
-                S,
-                NonNullable<Message["guild"]>,
-                Message["guild"]
-            >;
-            readonly member: IsGuildOnly<
-                S,
-                NonNullable<Message["member"]>,
-                Message["member"]
-            >;
-        };
-        readonly guild: IsGuildOnly<
-            S,
-            NonNullable<Message["guild"]>,
-            Message["guild"]
-        >;
-        readonly member: IsGuildOnly<
-            S,
-            NonNullable<Message["member"]>,
-            Message["member"]
-        >;
+        readonly message: Message & MessageExtension<S>;
         readonly options: ParseOptions;
         readonly commandSet: CommandSet;
         readonly command: Command;
-    }
+    } & MessageExtension<S>
 ) => any | Promise<any>;

--- a/src/models/callbacks/CommandExecutor.ts
+++ b/src/models/callbacks/CommandExecutor.ts
@@ -1,4 +1,4 @@
-import { Message, Guild, GuildMember } from "discord.js";
+import { Message } from "discord.js";
 import { CommandSet } from "../CommandSet";
 
 import {
@@ -9,9 +9,11 @@ import { ParsableTypeOf } from "../ParsableType";
 import { ParseOptions } from "../ParseOptions";
 import { Command } from "../Command";
 
-type IsGuildOnly<S extends CommandSettings> = S["guildOnly"] extends true
-    ? never
-    : null;
+type IsGuildOnly<
+    S extends CommandSettings,
+    True,
+    False
+> = S["guildOnly"] extends true ? True : False;
 
 export type CommandExecutor<
     T extends CommandDefinition = CommandDefinition,
@@ -40,11 +42,27 @@ export type CommandExecutor<
             ? void
             : readonly ParsableTypeOf<NonNullable<T["rest"]>["type"]>[];
         readonly message: Message & {
-            readonly guild: Guild | IsGuildOnly<S>;
-            readonly member: GuildMember | IsGuildOnly<S>;
+            readonly guild: IsGuildOnly<
+                S,
+                NonNullable<Message["guild"]>,
+                Message["guild"]
+            >;
+            readonly member: IsGuildOnly<
+                S,
+                NonNullable<Message["member"]>,
+                Message["member"]
+            >;
         };
-        readonly guild: Guild | IsGuildOnly<S>;
-        readonly member: GuildMember | IsGuildOnly<S>;
+        readonly guild: IsGuildOnly<
+            S,
+            NonNullable<Message["guild"]>,
+            Message["guild"]
+        >;
+        readonly member: IsGuildOnly<
+            S,
+            NonNullable<Message["member"]>,
+            Message["member"]
+        >;
         readonly options: ParseOptions;
         readonly commandSet: CommandSet;
         readonly command: Command;


### PR DESCRIPTION
- resolve #72 

### Features

- In the command executor the `Message#channel` field type exclude `DMChannel` if `guildOnly` is set to true.