### PR TITLE
feat(Help Display): usage section only if executor is set / subs displayed only if user have permissions

### DIFF
--- a/src/commands/help.cmd.ts
+++ b/src/commands/help.cmd.ts
@@ -48,7 +48,8 @@ cmd.executor = async (_a, _f, { rest, options, commandSet, message }) => {
             const embed = HelpUtils.Command.embedHelp(
                 command,
                 options.prefix,
-                options.localization
+                options.localization,
+                message
             );
             await reply(message, { embed });
         }

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -171,6 +171,11 @@ export class Command {
         return undefined;
     }
 
+    /** Return true if this command have an executor, false otherwise. */
+    get hasExecutor(): boolean {
+        return this._executor !== undefined;
+    }
+
     /** Create and return an array containing all parent of this command, ordered from top-most command to this command (included). */
     getParents() {
         const parents: Command[] = [];

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -116,21 +116,24 @@ export namespace HelpUtils {
                               rawHelp.tags.map((t) => `\`${t}\``).join(" "))
                 );
 
-            const usageString =
-                prefix +
-                rawHelp.fullName +
-                (rawHelp.args.length === 0
-                    ? ""
-                    : " " + rawHelp.args.map((a) => a.usageString).join(" ")) +
-                (rawHelp.rest ? " " + rawHelp.rest.usageString : "");
-            embed.addField(
-                localization.help.usage,
-                `**\`${usageString}\`**` +
-                    (rawHelp.args.length !== 0
-                        ? `\n\n${localization.help.argUsageHint}`
-                        : ""),
-                false
-            );
+            if (command.hasExecutor) {
+                const usageString =
+                    prefix +
+                    rawHelp.fullName +
+                    (rawHelp.args.length === 0
+                        ? ""
+                        : " " +
+                          rawHelp.args.map((a) => a.usageString).join(" ")) +
+                    (rawHelp.rest ? " " + rawHelp.rest.usageString : "");
+                embed.addField(
+                    localization.help.usage,
+                    `**\`${usageString}\`**` +
+                        (rawHelp.args.length !== 0
+                            ? `\n\n${localization.help.argUsageHint}`
+                            : ""),
+                    false
+                );
+            }
 
             const args =
                 rawHelp.args

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -1,6 +1,6 @@
 import { Command } from "../models/Command"; /* eslint-disable-line @typescript-eslint/no-unused-vars */ // due to namespace Command: will be remove in future
 import { Localization } from "../models/localization/Localization";
-import { MessageEmbed } from "discord.js";
+import { MessageEmbed, Message } from "discord.js";
 import { TypeNameLocalization } from "../models/localization/TypeNameLocalization";
 import { FlagDefinition } from "../models/definition/FlagDefinition";
 import { ArgDefinition } from "../models/definition/ArgDefinition";
@@ -102,7 +102,8 @@ export namespace HelpUtils {
         export function embedHelp(
             command: Command,
             prefix: string,
-            localization: Localization
+            localization: Localization,
+            message?: Message
         ) {
             const rawHelp = getRawHelp(command, localization);
 
@@ -169,7 +170,12 @@ export namespace HelpUtils {
             if (flags !== "")
                 embed.addField(localization.help.flags, flags, true);
 
-            const subs = rawHelp.subs
+            const subs = (message
+                ? rawHelp.subs.filter((s) =>
+                      s.command.checkPermissions(message)
+                  )
+                : rawHelp.subs
+            )
                 .map(
                     (s) =>
                         `\`${s.command.name}\`` +

--- a/test/commands/onlySubs.cmd.ts
+++ b/test/commands/onlySubs.cmd.ts
@@ -4,6 +4,7 @@ const cmd = makeCommand("onlySubs", {
     subs: {
         a: {},
         b: {},
+        c: { canUse: () => false },
     },
 });
 

--- a/test/commands/onlySubs.cmd.ts
+++ b/test/commands/onlySubs.cmd.ts
@@ -1,0 +1,18 @@
+import { makeCommand } from "../../src/index";
+
+const cmd = makeCommand("onlySubs", {
+    subs: {
+        a: {},
+        b: {},
+    },
+});
+
+cmd.subs.a.executor = async (_a, _f, { message }) => {
+    await message.reply("A");
+};
+
+cmd.subs.b.executor = async (_a, _f, { message }) => {
+    await message.reply("B");
+};
+
+export default cmd;


### PR DESCRIPTION
- resolve #108: Sub-commands are not displayed if the user cannot use them.
- resolve #109: The `usage` section is not displayed if the `executor` of the command is not set.