### PR TITLE
feat(Help System): CommandSet level help handler

### DIFF
--- a/src/commands/help.cmd.ts
+++ b/src/commands/help.cmd.ts
@@ -1,4 +1,3 @@
-import { HelpUtils } from "../other/HelpUtils";
 import { template } from "../utils/template";
 import { makeCommand } from "../other/makeCommand";
 import { reply } from "../utils/reply";
@@ -44,14 +43,7 @@ cmd.executor = async (_a, _f, { rest, options, commandSet, message }) => {
             )
                 return;
 
-            if (await command.help(message, options)) return;
-            const embed = HelpUtils.Command.embedHelp(
-                command,
-                options.prefix,
-                options.localization,
-                message
-            );
-            await reply(message, { embed });
+            await command.help(message, options);
         }
     }
 };

--- a/src/models/Command.ts
+++ b/src/models/Command.ts
@@ -29,6 +29,7 @@ import { ParsableType } from "./ParsableType";
 import { ThrottlingDefinition } from "./definition/ThrottlingDefinition";
 import { Throttler } from "./Throttler";
 import { CommandLoadError } from "./errors/CommandLoadError";
+import { HelpUtils } from "../other/HelpUtils";
 
 export class Command {
     private readonly _throttler: Throttler | null | undefined;
@@ -226,14 +227,20 @@ export class Command {
      * @param message
      * @param options
      */
-    async help(message: Message, options: ParseOptions): Promise<boolean> {
-        if (!this._help) return false;
-        await this._help(this, {
+    async help(message: Message, options: ParseOptions) {
+        const context = {
             message,
             options,
             commandSet: this.commandSet,
-        });
-        return true;
+        };
+
+        if (this._help) {
+            await this._help(this, context);
+        } else if (this.commandSet.helpHandler) {
+            await this.commandSet.helpHandler(this, context);
+        } else {
+            await HelpUtils.DefaultHelp(this, context);
+        }
     }
 
     /** @internal */

--- a/src/models/CommandSet.ts
+++ b/src/models/CommandSet.ts
@@ -21,11 +21,13 @@ import {
 import PathUtils from "../utils/PathUtils";
 import chalk from "chalk";
 import { CommandLoadError } from "./errors/CommandLoadError";
+import { HelpCb } from "./callbacks/HelpCb";
 
 type BuildInCommand = "help" | "list" | "cmd";
 
 export class CommandSet {
     private _commands = new CommandCollection();
+    public helpHandler: HelpCb | undefined = undefined;
 
     constructor(private _defaultOptions?: DeepPartial<ParseOptions>) {}
 

--- a/src/other/HelpUtils.ts
+++ b/src/other/HelpUtils.ts
@@ -11,6 +11,8 @@ import { RestRawHelp } from "../models/data/help/RestRawHelp";
 import { CommandLocalization } from "../models/localization/CommandLocalization";
 import { ArrayUtils } from "../utils/array";
 import { template } from "../utils/template";
+import { reply } from "../utils/reply";
+import { ParseOptions } from "../models/ParseOptions";
 
 // TODO: remove namespace for HelpUtils and Command
 // replace by a single class CommandHelp
@@ -18,6 +20,19 @@ import { template } from "../utils/template";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace HelpUtils {
+    export async function DefaultHelp(
+        command: Command,
+        { message, options }: { message: Message; options: ParseOptions }
+    ) {
+        const embed = HelpUtils.Command.embedHelp(
+            command,
+            options.prefix,
+            options.localization,
+            message
+        );
+        await reply(message, { embed });
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-namespace
     export namespace Command {
         export function getFullName(command: Command) {

--- a/test/commands/onlySubs.cmd.ts
+++ b/test/commands/onlySubs.cmd.ts
@@ -6,6 +6,10 @@ const cmd = makeCommand("onlySubs", {
         b: {},
         c: { canUse: () => false },
     },
+    useHelpOnSubs: true,
+    help: async (c, { message }) => {
+        await message.reply(`[HELP] onlySubs ${c.name}`);
+    },
 });
 
 cmd.subs.a.executor = async (_a, _f, { message }) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,5 @@
 import { Client } from "discord.js";
-import { CommandSet } from "../src/index";
+import { CommandSet, HelpUtils } from "../src/index";
 import { Logger } from "../src/logger";
 import env from "./env.json";
 
@@ -10,6 +10,16 @@ const commands = new CommandSet({
     devIDs: env.devIDs,
     skipDevsPermissionsChecking: env.skipDevsPermissionshecking,
 });
+
+commands.helpHandler = async (command, { message, options }) => {
+    const help = HelpUtils.Command.getRawHelp(command, options.localization);
+    const text = `
+**Command name**: ${command.name}
+**Full name**: ${help.fullName}
+`;
+    await message.reply(text);
+};
+
 commands.loadCommands("commands", true);
 
 // manually load build-in commands


### PR DESCRIPTION
- resolve #88 
Add a help handler to `CommandSet` that is called when a command need to display help and if this command don't define its own help handler.