### PR TITLE
feat(cli): create command path options

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "release": "ts-node chores/release.ts",
         "v": "npm --no-git-tag-version version",
         "test": "npm run lint && npm run build:test",
+        "test:cmd": "ts-node ./src/bin/cli.ts cmd -l ts -p ./test/commands",
         "build:test": "tsc",
         "start": "ts-node test/index.ts",
         "start:log": "ts-node test/log.ts",

--- a/src/bin/new-command.ts
+++ b/src/bin/new-command.ts
@@ -40,7 +40,7 @@ export default function () {
 
     fs.mkdirSync(dir, { recursive: true });
 
-    let filePath = path.resolve(
+    const filePath = path.resolve(
         path.format({
             dir,
             name,

--- a/src/bin/new-command.ts
+++ b/src/bin/new-command.ts
@@ -8,6 +8,7 @@ Usage
     dbc cmd path/to/file_without_extension [options]
 Options
     --lang, -l <js|ts>  Define the language. Javascript (js) or Typescript (ts). (Default = js)
+    --path, -p <path> Path to the location of the command.
 `;
 
 export default function () {
@@ -17,6 +18,10 @@ export default function () {
                 type: "string",
                 alias: "l",
                 default: "js",
+            },
+            path: {
+                type: "string",
+                alias: "p",
             },
         },
     });
@@ -29,20 +34,22 @@ export default function () {
     }
 
     const ext = cli.flags.lang;
-    const parsedPath = path.parse(cli.input[1]);
+    const { dir: cmdDir, base: name } = path.parse(cli.input[1]);
 
-    fs.mkdirSync(parsedPath.dir, { recursive: true });
+    const dir = cli.flags.path ? path.join(cli.flags.path, cmdDir) : cmdDir;
 
-    const filePath = path.resolve(
+    fs.mkdirSync(dir, { recursive: true });
+
+    let filePath = path.resolve(
         path.format({
-            dir: parsedPath.dir,
-            name: parsedPath.name,
+            dir,
+            name,
             ext: ".cmd." + ext,
         }),
     );
 
     const templatePath = path.resolve(__dirname, "../assets/templates/command." + ext + ".template");
 
-    const template = fs.readFileSync(templatePath).toString().replace("$NAME$", parsedPath.name);
+    const template = fs.readFileSync(templatePath).toString().replace("$NAME$", name);
     fs.writeFileSync(filePath, template, { flag: "wx" });
 }


### PR DESCRIPTION
Add `path` options to new command cli.
It's avoid to retype full path when using `npm run`

## Usage
**Package.json**
```json
{
    "scripts": {
        "cmd": "dbc cmd -l ts -p ./src/commands"
    }
}
```

```sh
npm run cmd ping
npm run cmd sub/ping
```