### PR TITLE
fix(CommandExecutor): remove @internal on MessageExtension

### DIFF
--- a/src/models/callbacks/CommandExecutor.ts
+++ b/src/models/callbacks/CommandExecutor.ts
@@ -6,10 +6,10 @@ import { ParsableTypeOf } from "../ParsableType";
 import { CommandSetOptions } from "../CommandSetOptions";
 import { Command } from "../Command";
 
-/** @internal */
+/** @ignore */
 type IsGuildOnly<S extends CommandSettings, True, False> = S["guildOnly"] extends true ? True : False;
 
-/** @internal */
+/** @ignore */
 type MessageExtension<S> = {
     readonly guild: IsGuildOnly<S, NonNullable<Message["guild"]>, Message["guild"]>;
     readonly member: IsGuildOnly<S, NonNullable<Message["member"]>, Message["member"]>;


### PR DESCRIPTION
Fix build

### Error
```
node_modules/discord-bot-cli/dist/models/callbacks/CommandExecutor.d.ts:17:33 - error TS2304: Cannot find name 'MessageExtension'.

17     readonly message: Message & MessageExtension<S>;
                                   ~~~~~~~~~~~~~~~~

node_modules/discord-bot-cli/dist/models/callbacks/CommandExecutor.d.ts:21:5 - 
error TS2304: Cannot find name 'MessageExtension'.

21 } & MessageExtension<S>) => any | Promise<any>;
       ~~~~~~~~~~~~~~~~

```