### PR TITLE
refactorize (Parse): Clean up Parser

### DIFF
--- a/src/lib/models/Command.ts
+++ b/src/lib/models/Command.ts
@@ -463,7 +463,7 @@ export class Command {
 
             if (cur.data.parser) {
                 try {
-                    const value = cur.data.parser._parse(context);
+                    const value = cur.data.parser.parse(context);
                     flags.set(cur.data.key, value);
                 } catch (e) {
                     const error = e instanceof ParseError ? e : new UnhandledErrorParseError(e);
@@ -507,7 +507,7 @@ export class Command {
 
             const current = context.consumed;
             try {
-                return def.parser._parse(context);
+                return def.parser.parse(context);
             } catch (e) {
                 const position = absolutePositions[current];
                 if (!position) throw Error("Shouldn't happen !");

--- a/src/lib/models/parsers/Parser.ts
+++ b/src/lib/models/parsers/Parser.ts
@@ -110,7 +110,7 @@ class FunctionParser<T> extends CustomParser<T> {
     }
 }
 
-abstract class WrapperParser<I, O = I> extends Parser<O> {
+export abstract class WrapperParser<I, O = I> extends Parser<O> {
     constructor(public readonly inner: Parser<I>) {
         super();
     }

--- a/src/lib/models/parsers/ParsingContext.ts
+++ b/src/lib/models/parsers/ParsingContext.ts
@@ -45,6 +45,15 @@ export class ParsingContext {
         return context;
     }
 
+    /**
+     * Checks if the remaining number of arguments is greater or equals than the expected number of arguments.
+     * If it's not the case, throws an `NotEnoughArgParseError` error.
+     * @param minimumArgExpected The minimum number of arguments expected
+     */
+    public require(minimumArgExpected: number): void {
+        if (this.remaining < minimumArgExpected) throw new NotEnoughArgParseError(minimumArgExpected, this.remaining);
+    }
+
     private next(): ArgItem {
         if (this.current === this.to) throw new NotEnoughArgParseError(1, 0);
         // to is never greater than args length.

--- a/src/lib/models/parsers/ParsingContext.ts
+++ b/src/lib/models/parsers/ParsingContext.ts
@@ -54,10 +54,27 @@ export class ParsingContext {
         if (this.remaining < minimumArgExpected) throw new NotEnoughArgParseError(minimumArgExpected, this.remaining);
     }
 
-    private next(): ArgItem {
+    /**
+     * Consumes the next argument and returns it.
+     * @returns The next argument
+     * @throws {NotEnoughArgParseError} If the remaining number of argument is 0
+     *
+     */
+    next(): ArgItem {
         if (this.current === this.to) throw new NotEnoughArgParseError(1, 0);
         // to is never greater than args length.
         return this.args[this.current++]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    }
+
+    /**
+     * Returns the next arguments without consumes it.
+     * @returns The next argument
+     * @throws {NotEnoughArgParseError} If the remaining number of argument is 0
+     */
+    peek(): ArgItem {
+        if (this.current === this.to) throw new NotEnoughArgParseError(1, 0);
+        // to is never greater than args length.
+        return this.args[this.current]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
     }
 
     nextString(): string {

--- a/src/lib/models/parsers/buildin/RestParser.ts
+++ b/src/lib/models/parsers/buildin/RestParser.ts
@@ -1,0 +1,35 @@
+import { NotEnoughArgParseError } from "../errors";
+import { Parser, WrapperParser } from "../Parser";
+import { ParsingContext } from "../ParsingContext";
+
+export class RestParser<T> extends WrapperParser<T, T[]> {
+    constructor(inner: Parser<T>) {
+        super(inner);
+    }
+
+    get typeName() {
+        return this.inner.typeName + "...";
+    }
+
+    public parse(context: ParsingContext): T[] {
+        const rest: T[] = [];
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            try {
+                rest.push(this.inner.parse(context));
+            } catch (e) {
+                if (e instanceof NotEnoughArgParseError) return rest;
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Parse every remaining arguments using the inner parser.
+     * @param inner The parser used to parse arguments
+     */
+    static create<T>(inner: Parser<T>): Parser<T[]> {
+        return new RestParser(inner);
+    }
+}

--- a/src/lib/models/parsers/buildin/UnionParser.ts
+++ b/src/lib/models/parsers/buildin/UnionParser.ts
@@ -2,20 +2,20 @@ import { InvalidUnionTypeParseError, ParseError } from "../errors";
 import { CustomParser, Parser, ParserType } from "../Parser";
 import { ParsingContext } from "../ParsingContext";
 
-export class UnionParser<T extends Parser<unknown>[] = Parser<unknown>[]> extends CustomParser<ParserType<T[number]>> {
-    public readonly inners: Readonly<T>;
+export class UnionParser<P extends Parser<unknown>[] = Parser<unknown>[]> extends CustomParser<ParserType<P[number]>> {
+    public readonly inners: Readonly<P>;
 
-    constructor(...parsers: T) {
+    constructor(...parsers: P) {
         super(parsers.map(p => p.typeName).join(" | "));
         this.inners = parsers;
     }
 
-    public parse(context: ParsingContext): ParserType<T[number]> {
+    public parse(context: ParsingContext): ParserType<P[number]> {
         context.saveState();
         for (const parser of this.inners) {
             try {
                 context.restoreState();
-                const value = parser.parse(context) as ParserType<T[number]>;
+                const value = parser.parse(context) as ParserType<P[number]>;
                 context.removeState();
                 return value;
             } catch (e) {

--- a/src/lib/models/parsers/buildin/UnionParser.ts
+++ b/src/lib/models/parsers/buildin/UnionParser.ts
@@ -24,4 +24,11 @@ export class UnionParser<T extends Parser<unknown>[] = Parser<unknown>[]> extend
         }
         throw new InvalidUnionTypeParseError(this);
     }
+
+    /**
+     * Parses the value using each parser **in order** until the first that successfully parse the value.
+     */
+    static create<P extends Parser<unknown>[] = Parser<unknown>[]>(...parsers: P): Parser<ParserType<P[number]>> {
+        return new UnionParser(...parsers);
+    }
 }

--- a/src/lib/models/parsers/buildin/UnionParser.ts
+++ b/src/lib/models/parsers/buildin/UnionParser.ts
@@ -6,7 +6,7 @@ export class UnionParser<T extends Parser<unknown>[] = Parser<unknown>[]> extend
     private readonly parsers: T;
 
     constructor(...parsers: T) {
-        super(parsers.map(p => p.typeName).join(" | "), Math.min(...parsers.map(p => p.minimalInputRequired)));
+        super(parsers.map(p => p.typeName).join(" | "));
         this.parsers = parsers;
     }
 
@@ -15,7 +15,7 @@ export class UnionParser<T extends Parser<unknown>[] = Parser<unknown>[]> extend
         for (const parser of this.parsers) {
             try {
                 context.restoreState();
-                const value = parser._parse(context) as ParserType<T[number]>;
+                const value = parser.parse(context) as ParserType<T[number]>;
                 context.removeState();
                 return value;
             } catch (e) {

--- a/src/lib/models/parsers/buildin/UnionParser.ts
+++ b/src/lib/models/parsers/buildin/UnionParser.ts
@@ -3,16 +3,16 @@ import { CustomParser, Parser, ParserType } from "../Parser";
 import { ParsingContext } from "../ParsingContext";
 
 export class UnionParser<T extends Parser<unknown>[] = Parser<unknown>[]> extends CustomParser<ParserType<T[number]>> {
-    private readonly parsers: T;
+    public readonly inners: Readonly<T>;
 
     constructor(...parsers: T) {
         super(parsers.map(p => p.typeName).join(" | "));
-        this.parsers = parsers;
+        this.inners = parsers;
     }
 
     public parse(context: ParsingContext): ParserType<T[number]> {
         context.saveState();
-        for (const parser of this.parsers) {
+        for (const parser of this.inners) {
             try {
                 context.restoreState();
                 const value = parser.parse(context) as ParserType<T[number]>;

--- a/src/lib/models/parsers/buildin/discord.ts
+++ b/src/lib/models/parsers/buildin/discord.ts
@@ -62,7 +62,6 @@ function discordParser<T>(
 
 export const USER_PARSER = Parser.fromFunction(
     "$user$",
-    1,
     discordParser(
         USERS_PATTERN,
         m => m.users,
@@ -73,7 +72,6 @@ export const USER_PARSER = Parser.fromFunction(
 
 export const ROLE_PARSER = Parser.fromFunction(
     "$role$",
-    1,
     discordParser(
         ROLES_PATTERN,
         m => m.roles,
@@ -90,7 +88,7 @@ const CHANNEL_PARSER_FC = discordParser(
     UnresolvedChannelParseError,
 );
 
-export const CHANNEL_PARSER = Parser.fromFunction("$channel$", 1, CHANNEL_PARSER_FC);
+export const CHANNEL_PARSER = Parser.fromFunction("$channel$", CHANNEL_PARSER_FC);
 
 export function channelParser(): Parser<Channel>;
 /** Parses a channel and checks its type is one of the provided. */
@@ -105,7 +103,7 @@ export function channelParser<Type extends Exclude<Channel["type"], "unknown" | 
     types = distinct(types).sort();
     const typeName = types.map(t => `$${t} channel$`).join(" | ");
 
-    return Parser.fromFunction(typeName, 1, CHANNEL_PARSER_FC).if(
+    return Parser.fromFunction(typeName, CHANNEL_PARSER_FC).if(
         (c): c is Type2Channel<Type> => types.includes(c.type as Type),
         c => new WrongTypeChannelParseError(c, types),
     );

--- a/src/lib/models/parsers/buildin/index.ts
+++ b/src/lib/models/parsers/buildin/index.ts
@@ -1,3 +1,4 @@
-export * from "./UnionParser";
 export * from "./primitives";
 export * from "./discord";
+export * from "./UnionParser";
+export * from "./RestParser";

--- a/src/lib/models/parsers/buildin/primitives.ts
+++ b/src/lib/models/parsers/buildin/primitives.ts
@@ -1,23 +1,6 @@
-import { NotEnoughArgParseError } from "../errors";
 import { Parser } from "../Parser";
 
 export const STRING_PARSER = Parser.fromFunction("$string$", ctx => ctx.nextString());
 export const INTEGER_PARSER = Parser.fromFunction("$integer$", ctx => ctx.nextInteger());
 export const FLOAT_PARSER = Parser.fromFunction("$float$", ctx => ctx.nextFloat());
 export const BOOLEAN_PARSER = Parser.fromFunction("$boolean$", ctx => ctx.nextBoolean());
-
-export function restParser<T>(parser: Parser<T>): Parser<T[]> {
-    return Parser.fromFunction(parser.typeName + "...", ctx => {
-        const rest: T[] = [];
-
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-            try {
-                rest.push(parser.parse(ctx));
-            } catch (e) {
-                if (e instanceof NotEnoughArgParseError) return rest;
-                throw e;
-            }
-        }
-    });
-}

--- a/src/lib/models/parsers/buildin/primitives.ts
+++ b/src/lib/models/parsers/buildin/primitives.ts
@@ -1,13 +1,13 @@
 import { NotEnoughArgParseError } from "../errors";
 import { Parser } from "../Parser";
 
-export const STRING_PARSER = Parser.fromFunction("$string$", 1, ctx => ctx.nextString());
-export const INTEGER_PARSER = Parser.fromFunction("$integer$", 1, ctx => ctx.nextInteger());
-export const FLOAT_PARSER = Parser.fromFunction("$float$", 1, ctx => ctx.nextFloat());
-export const BOOLEAN_PARSER = Parser.fromFunction("$boolean$", 1, ctx => ctx.nextBoolean());
+export const STRING_PARSER = Parser.fromFunction("$string$", ctx => ctx.nextString());
+export const INTEGER_PARSER = Parser.fromFunction("$integer$", ctx => ctx.nextInteger());
+export const FLOAT_PARSER = Parser.fromFunction("$float$", ctx => ctx.nextFloat());
+export const BOOLEAN_PARSER = Parser.fromFunction("$boolean$", ctx => ctx.nextBoolean());
 
 export function restParser<T>(parser: Parser<T>): Parser<T[]> {
-    return Parser.fromFunction(parser.typeName + "...", 0, ctx => {
+    return Parser.fromFunction(parser.typeName + "...", ctx => {
         const rest: T[] = [];
 
         // eslint-disable-next-line no-constant-condition

--- a/src/lib/models/parsers/buildin/primitives.ts
+++ b/src/lib/models/parsers/buildin/primitives.ts
@@ -1,6 +1,43 @@
+import { InvalidRangeParseError } from "../errors";
 import { Parser } from "../Parser";
 
 export const STRING_PARSER = Parser.fromFunction("$string$", ctx => ctx.nextString());
 export const INTEGER_PARSER = Parser.fromFunction("$integer$", ctx => ctx.nextInteger());
 export const FLOAT_PARSER = Parser.fromFunction("$float$", ctx => ctx.nextFloat());
 export const BOOLEAN_PARSER = Parser.fromFunction("$boolean$", ctx => ctx.nextBoolean());
+
+/**
+ * Parses a string and checks the value is one of the expected.
+ * @param values The expected values
+ */
+export function values<T extends string = never>(...values: T[]) {
+    return STRING_PARSER.if((s): s is T => values.includes(s as T));
+}
+
+/**
+ * Parses an interger and checks the value is in range [min; max).
+ *
+ * Raise `InvalidRangeParseError` if the value is not in the range.
+ * @param min The minimum value expected (included)
+ * @param max The maximum value expected (excluded)
+ */
+export function rangei(min: number, max: number) {
+    return INTEGER_PARSER.if(
+        n => n >= min && n < max,
+        n => new InvalidRangeParseError(n, min, max),
+    );
+}
+
+/**
+ * Parses a float and checks the value is in range [min; max].
+ *
+ * Raise `InvalidRangeParseError` if the value is not in the range.
+ * @param min The minimum value expected (included)
+ * @param max The maximum value expected (included)
+ */
+export function rangef(min: number, max: number) {
+    return FLOAT_PARSER.if(
+        n => n >= min && n <= max,
+        n => new InvalidRangeParseError(n, min, max),
+    );
+}

--- a/src/lib/models/parsers/index.ts
+++ b/src/lib/models/parsers/index.ts
@@ -1,14 +1,14 @@
 import {
     BOOLEAN_PARSER,
-    channelParser,
-    FLOAT_PARSER,
-    INTEGER_PARSER,
-    ROLE_PARSER,
     STRING_PARSER,
+    INTEGER_PARSER,
+    FLOAT_PARSER,
     UnionParser,
+    RestParser,
     USER_PARSER,
+    ROLE_PARSER,
+    channelParser,
 } from "./buildin";
-import { RestParser } from "./buildin/RestParser";
 import { InvalidRangeParseError } from "./errors";
 import { Parser } from "./Parser";
 

--- a/src/lib/models/parsers/index.ts
+++ b/src/lib/models/parsers/index.ts
@@ -3,12 +3,12 @@ import {
     channelParser,
     FLOAT_PARSER,
     INTEGER_PARSER,
-    restParser,
     ROLE_PARSER,
     STRING_PARSER,
     UnionParser,
     USER_PARSER,
 } from "./buildin";
+import { RestParser } from "./buildin/RestParser";
 import { InvalidRangeParseError } from "./errors";
 import { Parser } from "./Parser";
 
@@ -22,7 +22,7 @@ export const Parsers = Object.freeze({
     integer: INTEGER_PARSER,
     float: FLOAT_PARSER,
     boolean: BOOLEAN_PARSER,
-    rest: restParser,
+    rest: RestParser.create,
     user: USER_PARSER,
     role: ROLE_PARSER,
     channel: channelParser,

--- a/src/lib/models/parsers/index.ts
+++ b/src/lib/models/parsers/index.ts
@@ -18,25 +18,13 @@ export * from "./buildin";
 export * from "./errors";
 
 export const Parsers = Object.freeze({
-    get string() {
-        return STRING_PARSER;
-    },
-    get integer() {
-        return INTEGER_PARSER;
-    },
-    get float() {
-        return FLOAT_PARSER;
-    },
-    get boolean() {
-        return BOOLEAN_PARSER;
-    },
+    string: STRING_PARSER,
+    integer: INTEGER_PARSER,
+    float: FLOAT_PARSER,
+    boolean: BOOLEAN_PARSER,
     rest: restParser,
-    get user() {
-        return USER_PARSER;
-    },
-    get role() {
-        return ROLE_PARSER;
-    },
+    user: USER_PARSER,
+    role: ROLE_PARSER,
     channel: channelParser,
     /** Parses the value using each parser **in order** until the first that successfully parse the value.*/
     union: <T extends Parser<unknown>[] = Parser<unknown>[]>(...parsers: T) => {

--- a/src/lib/models/parsers/index.ts
+++ b/src/lib/models/parsers/index.ts
@@ -23,13 +23,10 @@ export const Parsers = Object.freeze({
     float: FLOAT_PARSER,
     boolean: BOOLEAN_PARSER,
     rest: RestParser.create,
+    union: UnionParser.create,
     user: USER_PARSER,
     role: ROLE_PARSER,
     channel: channelParser,
-    /** Parses the value using each parser **in order** until the first that successfully parse the value.*/
-    union: <T extends Parser<unknown>[] = Parser<unknown>[]>(...parsers: T) => {
-        return new UnionParser(...parsers);
-    },
     /** Parses an interger and checks the value is in range [min; max). */
     rangei: (min: number, max: number) =>
         INTEGER_PARSER.if(

--- a/src/lib/models/parsers/index.ts
+++ b/src/lib/models/parsers/index.ts
@@ -8,9 +8,10 @@ import {
     USER_PARSER,
     ROLE_PARSER,
     channelParser,
+    values,
+    rangei,
+    rangef,
 } from "./buildin";
-import { InvalidRangeParseError } from "./errors";
-import { Parser } from "./Parser";
 
 export * from "./Parser";
 export * from "./ParsingContext";
@@ -27,19 +28,7 @@ export const Parsers = Object.freeze({
     user: USER_PARSER,
     role: ROLE_PARSER,
     channel: channelParser,
-    /** Parses an interger and checks the value is in range [min; max). */
-    rangei: (min: number, max: number) =>
-        INTEGER_PARSER.if(
-            n => n >= min && n < max,
-            n => new InvalidRangeParseError(n, min, max),
-        ),
-    /** Parses a float and checks the value is in range [min; max]. */
-    rangef: (min: number, max: number) =>
-        FLOAT_PARSER.if(
-            n => n >= min && n <= max,
-            n => new InvalidRangeParseError(n, min, max),
-        ),
-    /** Parses a string and checks the value is one of the values. */
-    values: <T extends string = never>(...values: T[]): Parser<T> =>
-        STRING_PARSER.if((s): s is T => values.includes(s as T)),
+    values,
+    rangei,
+    rangef,
 });


### PR DESCRIPTION
## Parser
- Remove the internal `_parse` method
- export `WrapperParser`
- `RestParser` is now a class to expose it's inner parser
- `UnionParser` expose it's inner parsers

## ParserContext
- `next` is now public
- add `peek`

## Parsers
- Remove the getters
- Move create methods somewhere else